### PR TITLE
Less restrictive compatibility requirements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
 DataFrames = "1"
-Distributions = "0.25"
+Distributions = "0"
 RecipesBase = "1"
-Turing = "0.29"
+Turing = "0"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ActionModels"
 uuid = "320cf53b-cc3b-4b34-9a10-0ecb113566a3"
 authors = ["Peter Thestrup Waade <peter@waade.net>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"


### PR DESCRIPTION
Not sure how often breaking changes are made to dependencies, but I couldn't update Turing to v0.30.3